### PR TITLE
Implement play first feature

### DIFF
--- a/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
@@ -25,9 +25,6 @@ public abstract class LocalPlayer extends GamePlayer {
 
   // ===== LocalPlayer API ===== //
 
-  /** Called when the player receives a move message from the server. */
-  protected abstract void onMoveReceived();
-
   /** Computes the next move and sends it to the server. */
   protected abstract void move();
 
@@ -43,6 +40,9 @@ public abstract class LocalPlayer extends GamePlayer {
     gameGUI.updateGameState(queenCurrent, queenTarget, arrowTarget);
     gameClient.sendMoveMessage(queenCurrent, queenTarget, arrowTarget);
   }
+
+  /** Called when the player receives a move message from the server. */
+  private void onMoveReceived() { move(); }
 
   /** Called when the game starts if this player is black. */
   private void playFirstMove() { move(); }

--- a/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
@@ -29,7 +29,10 @@ public abstract class LocalPlayer extends GamePlayer {
   protected abstract void onMoveReceived();
 
   /** Called when the player receives a move message from the server. */
-  protected abstract void playFirstMove();
+  protected abstract void move();
+
+  /** Called when the player receives a move message from the server. */
+  private void playFirstMove() { move(); }
 
   /** Returns the list of actions that can be taken from the current state. */
   protected ArrayList<AmazonsAction> getAvailableActions() {

--- a/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
@@ -28,6 +28,9 @@ public abstract class LocalPlayer extends GamePlayer {
   /** Called when the player receives a move message from the server. */
   protected abstract void onMoveReceived();
 
+  /** Called when the player receives a move message from the server. */
+  protected abstract void playFirstMove();
+
   /** Returns the list of actions that can be taken from the current state. */
   protected ArrayList<AmazonsAction> getAvailableActions() {
     return actionFactory.getActions(board);
@@ -73,6 +76,8 @@ public abstract class LocalPlayer extends GamePlayer {
 
         board.localPlayer = whitePlayer.equals(username) ? 1 : 2;
         System.out.println("***** PLAYER INFO: " + username + " " + board.localPlayer + " *****");
+
+        if (board.localPlayer == 2) playFirstMove();
         break;
     }
 

--- a/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/LocalPlayer.java
@@ -28,11 +28,8 @@ public abstract class LocalPlayer extends GamePlayer {
   /** Called when the player receives a move message from the server. */
   protected abstract void onMoveReceived();
 
-  /** Called when the player receives a move message from the server. */
+  /** Computes the next move and sends it to the server. */
   protected abstract void move();
-
-  /** Called when the player receives a move message from the server. */
-  private void playFirstMove() { move(); }
 
   /** Returns the list of actions that can be taken from the current state. */
   protected ArrayList<AmazonsAction> getAvailableActions() {
@@ -46,6 +43,9 @@ public abstract class LocalPlayer extends GamePlayer {
     gameGUI.updateGameState(queenCurrent, queenTarget, arrowTarget);
     gameClient.sendMoveMessage(queenCurrent, queenTarget, arrowTarget);
   }
+
+  /** Called when the game starts if this player is black. */
+  private void playFirstMove() { move(); }
 
   // ===== GamePlayer Overrides ===== //
 

--- a/team-01/src/main/java/ubc/cosc322/Main.java
+++ b/team-01/src/main/java/ubc/cosc322/Main.java
@@ -9,10 +9,10 @@ public class Main {
 	 */
 	public static void main(String[] args) {
 		// Uncomment one of the following lines based on the desired player type:
-		// HumanPlayer player = new HumanPlayer();
+		HumanPlayer player = new HumanPlayer();
 		// Spectator player = new Spectator(args[0], args[1]);
 		// RandomPlayer player = new RandomPlayer();
-		MonteCarloPlayer player = new MonteCarloPlayer();
+		// MonteCarloPlayer player = new MonteCarloPlayer();
 
 		if (player.getGameGUI() == null) {
 			player.Go();

--- a/team-01/src/main/java/ubc/cosc322/Main.java
+++ b/team-01/src/main/java/ubc/cosc322/Main.java
@@ -9,10 +9,10 @@ public class Main {
 	 */
 	public static void main(String[] args) {
 		// Uncomment one of the following lines based on the desired player type:
-		HumanPlayer player = new HumanPlayer();
+		// HumanPlayer player = new HumanPlayer();
 		// Spectator player = new Spectator(args[0], args[1]);
 		// RandomPlayer player = new RandomPlayer();
-		// MonteCarloPlayer player = new MonteCarloPlayer();
+		MonteCarloPlayer player = new MonteCarloPlayer();
 
 		if (player.getGameGUI() == null) {
 			player.Go();

--- a/team-01/src/main/java/ubc/cosc322/MonteCarloPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/MonteCarloPlayer.java
@@ -74,6 +74,9 @@ public class MonteCarloPlayer extends LocalPlayer {
 		sendMove(action.queenCurrent, action.queenTarget, action.arrowTarget);
 	}
 
+	@Override
+	protected void playFirstMove() {};
+
 	private TreeNode getBestMove(TreeNode root) {
 		int maxWins = -1;
 		TreeNode best = null;

--- a/team-01/src/main/java/ubc/cosc322/MonteCarloPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/MonteCarloPlayer.java
@@ -45,11 +45,6 @@ public class MonteCarloPlayer extends LocalPlayer {
 	}
 
 	@Override
-	protected void onMoveReceived() {
-		move();
-	}
-
-	@Override
 	protected void move() {
 		root = new TreeNode(board);
 

--- a/team-01/src/main/java/ubc/cosc322/MonteCarloPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/MonteCarloPlayer.java
@@ -46,6 +46,11 @@ public class MonteCarloPlayer extends LocalPlayer {
 
 	@Override
 	protected void onMoveReceived() {
+		move();
+	}
+
+	@Override
+	protected void move() {
 		root = new TreeNode(board);
 
 		long startTime = System.currentTimeMillis();
@@ -73,9 +78,6 @@ public class MonteCarloPlayer extends LocalPlayer {
 		AmazonsAction action = root.getAction();
 		sendMove(action.queenCurrent, action.queenTarget, action.arrowTarget);
 	}
-
-	@Override
-	protected void playFirstMove() {};
 
 	private TreeNode getBestMove(TreeNode root) {
 		int maxWins = -1;

--- a/team-01/src/main/java/ubc/cosc322/RandomPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/RandomPlayer.java
@@ -8,6 +8,9 @@ public class RandomPlayer extends LocalPlayer {
 	}
 
 	@Override
+	protected void playFirstMove() {};
+
+	@Override
 	protected void onMoveReceived() {
 		ArrayList<AmazonsAction> actions = getAvailableActions();
 		int randomIndex = (int) (Math.random() * (actions.size() + 1));

--- a/team-01/src/main/java/ubc/cosc322/RandomPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/RandomPlayer.java
@@ -8,11 +8,6 @@ public class RandomPlayer extends LocalPlayer {
 	}
 
 	@Override
-	protected void onMoveReceived() {
-		move();
-	}
-
-	@Override
 	protected void move() {
 		ArrayList<AmazonsAction> actions = getAvailableActions();
 		int randomIndex = (int) (Math.random() * (actions.size() + 1));

--- a/team-01/src/main/java/ubc/cosc322/RandomPlayer.java
+++ b/team-01/src/main/java/ubc/cosc322/RandomPlayer.java
@@ -8,10 +8,12 @@ public class RandomPlayer extends LocalPlayer {
 	}
 
 	@Override
-	protected void playFirstMove() {};
+	protected void onMoveReceived() {
+		move();
+	}
 
 	@Override
-	protected void onMoveReceived() {
+	protected void move() {
 		ArrayList<AmazonsAction> actions = getAvailableActions();
 		int randomIndex = (int) (Math.random() * (actions.size() + 1));
 

--- a/team-01/src/main/java/ubc/cosc322/Spectator.java
+++ b/team-01/src/main/java/ubc/cosc322/Spectator.java
@@ -12,6 +12,6 @@ public class Spectator extends LocalPlayer {
 
   @Override
   protected void move() {
-  	// Spectators do not move
+    // Spectators do not move
   }
 }

--- a/team-01/src/main/java/ubc/cosc322/Spectator.java
+++ b/team-01/src/main/java/ubc/cosc322/Spectator.java
@@ -5,11 +5,13 @@ public class Spectator extends LocalPlayer {
     super(username, password);
   }
 
-	@Override
-	protected void playFirstMove() {};
-
   @Override
   protected void onMoveReceived() {
     // Spectators do nothing when receiving a move
+  }
+
+  @Override
+  protected void move() {
+  	// Spectators do not move
   }
 }

--- a/team-01/src/main/java/ubc/cosc322/Spectator.java
+++ b/team-01/src/main/java/ubc/cosc322/Spectator.java
@@ -5,6 +5,9 @@ public class Spectator extends LocalPlayer {
     super(username, password);
   }
 
+	@Override
+	protected void playFirstMove() {};
+
   @Override
   protected void onMoveReceived() {
     // Spectators do nothing when receiving a move

--- a/team-01/src/main/java/ubc/cosc322/Spectator.java
+++ b/team-01/src/main/java/ubc/cosc322/Spectator.java
@@ -6,11 +6,6 @@ public class Spectator extends LocalPlayer {
   }
 
   @Override
-  protected void onMoveReceived() {
-    // Spectators do nothing when receiving a move
-  }
-
-  @Override
   protected void move() {
     // Spectators do not move
   }


### PR DESCRIPTION
PLEASE READ:

1. I named the method `playFirstMove()` instead of `onFirstMove()` because I wanted to give it a name with an imperative mood, because "on(...)" makes it sound like a listener.

2. Now, I made a couple other changes. I first had it so that `onFirstMove()` was abstract, but both the random and the Monte Carlo player had the same implementation: `move()`. So I made `onFirstMove()` non-abstract, making it `onFirstMove() { move(); }` and instead made `move()` abstract (which I think makes a lot of sense). The move method is the entire body of the former `onMoveReceived()` method. Again, we had the same situation as before, with the two active players having the same implementation of `onMoveReceived()`, which was just `move()`. So I decided to make it non-abstract as well, making it  `onMoveReceived() { move(); }`. This works well, giving the LocalPlayer API only one abstract method: `move()`.

I'm obviously open to any disagreeing opinions. Thanks for reviewing!

close #43 